### PR TITLE
Add optional message for wait helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ helpers.displayHover($('.some-element'));
 
 * `waitForElement` - Waits for an element to be shown.
 ```js
-helpers.waitForElement($('.some-element'), timeout);
+helpers.waitForElement($('.some-element'), timeout, opt_message);
 ```
 
 * `waitForElementToDisappear` - Waits for an element not to be shown.
 ```js
-helpers.waitForElementToDisappear($('.some-element'), timeout);
+helpers.waitForElementToDisappear($('.some-element'), timeout, opt_message);
 ```
 
 * `selectOptionByText` - Selects an element from a selection box.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -60,7 +60,7 @@ Helpers.prototype.displayHover = function (element) {
 };
 
 // Calling isDisplayed when element is not present causes an exception.
-Helpers.prototype.waitForElement = function (element, timeout) {
+Helpers.prototype.waitForElement = function (element, timeout, opt_message) {
 	return browser.wait(function () {
 		return element.isPresent().then(function (isPresent) {
 			if (isPresent) {
@@ -70,11 +70,11 @@ Helpers.prototype.waitForElement = function (element, timeout) {
 				return false;
 			}
 		});
-	}, timeout || TIMEOUT);
+	}, timeout || TIMEOUT, opt_message);
 };
 
 // Calling isDisplayed when element is not present causes an exception.
-Helpers.prototype.waitForElementToDisappear = function (element, timeout) {
+Helpers.prototype.waitForElementToDisappear = function (element, timeout, opt_message) {
 	var _this = this;
 	return browser.wait(function () {
 		return element.isPresent().then(function (isPresent) {
@@ -85,7 +85,7 @@ Helpers.prototype.waitForElementToDisappear = function (element, timeout) {
 				return true;
 			}
 		});
-	}, timeout || TIMEOUT);
+	}, timeout || TIMEOUT, opt_message);
 };
 
 // Select element helper (filter by text)


### PR DESCRIPTION
The [wait](http://www.protractortest.org/#/api?view=webdriver.WebDriver.prototype.wait) method of protractor accepts custom timeout message as the third argument. 
Add the `opt_message` optional message parameter for the `waitForElement` and the `waitForElementToDisappear` methods.